### PR TITLE
Remove `--slurm_tmpdir` arg

### DIFF
--- a/docs/usage/useful_options.md
+++ b/docs/usage/useful_options.md
@@ -69,10 +69,10 @@ system in order to update the file on-the-fly. This process can be extremely
 slow on network storages. To help with this, SCATTR always reads and writes the
 tractography to a temporary location (e.g. `/tmp`) before copying the output to
 the final output, significantly improving the time it takes for tractography to 
-be generated. On a network system, you may be unable to write to `/tmp`. An 
-alternative on systems with `SLURM` workload managers is to invoke 
-`--slurm_tmpdir`, which requests that the workflow write to the local temporary
-storage system (e.g. `/localscratch`) instead of the network temporary storage.
+be generated. On a network system, you may be unable to write to `/tmp`. 
+Currently, on systems using the `SLURM` workflow manager, the workflow will 
+write to the local temporary storage system (e.g. `SLURM_TMPDIR`) instead of the
+the default network temporary storage (e.g. `/tmp`). 
 
 ## BIDS Parsing limitations
 

--- a/scattr/config/snakebids.yml
+++ b/scattr/config/snakebids.yml
@@ -48,6 +48,9 @@ pybids_inputs:
       - subject
       - session
 
+default-resources:
+  - tmpdir=__import__('os').environ.get("SLURM_TMPDIR') or system_tmpdir
+
 # Configuration for the command-line parameters to make available
 # passed on the argparse add_argument()
 parse_args:
@@ -84,14 +87,6 @@ parse_args:
 #-----------------------------------------------------#
 
 #--- additional BIDS-app options --- (add in below) --#
-  --slurm_tmpdir:
-    help: Flag to indicate use of SLURM temporary directory. A temporary 
-          directory is used to improve write speeds of output files on a 
-          networked system. If not used, the workflow will default to system 
-          /tmp directory
-    action: store_true
-    default: False
-
   --freesurfer_dir:
     help: The path to the freesurfer directory. If not provided, workflow
           assumes the directory exists at <output_dir>/freesurfer.

--- a/scattr/workflow/rules/mrtpipelines.smk
+++ b/scattr/workflow/rules/mrtpipelines.smk
@@ -379,15 +379,11 @@ rule tckgen:
     threads: 32
     resources:
         tmp_dir=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             **wildcards,
         ),
         tmp_tck=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="iFOD2",
             suffix="tractography.tck",
             **wildcards,
@@ -537,23 +533,17 @@ rule tck2connectome:
     threads: 32
     resources:
         tmp_dir=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             **wildcards,
         ),
         tmp_sl_assignment=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="subcortical",
             suffix="nodeAssignment.txt",
             **wildcards,
         ),
         tmp_node_weights=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="subcortical",
             suffix="nodeWeights.csv",
             **wildcards,
@@ -592,25 +582,19 @@ checkpoint connectome2tck:
     threads: 32
     resources:
         tmp_dir=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             datatype="unfiltered",
             **wildcards,
         ),
         edge_weight_prefix=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             datatype="unfiltered",
             desc="subcortical",
             suffix="tckWeights",
             **wildcards,
         ),
         edge_tck_prefix=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             datatype="unfiltered",
             desc="subcortical",
             suffix="from",
@@ -774,23 +758,17 @@ rule filter_combine_tck:
     threads: 1
     resources:
         tmp_dir=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             **wildcards,
         ),
         tmp_combined_tck=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="filteredsubcortical",
             suffix="tractography.tck",
             **wildcards,
         ),
         tmp_combined_weights=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="filteredsubcortical",
             suffix="tckWeights.txt",
             **wildcards,
@@ -832,23 +810,17 @@ rule filtered_tck2connectome:
     threads: 32
     resources:
         tmp_dir=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             **wildcards,
         ),
         tmp_sl_assignment=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="filteredsubcortical",
             suffix="nodeAssignment.txt",
             **wildcards,
         ),
         tmp_node_weights=lambda wildcards: bids_tractography_out(
-            root=os.environ.get("SLURM_TMPDIR")
-            if config.get("slurm_tmpdir")
-            else "/tmp",
+            root="{resources.tmpdir}",
             desc="filteredsubcortical",
             suffix="nodeWeights.csv",
             **wildcards,


### PR DESCRIPTION
## Proposed changes

Automatically set the `tmpdir` through the config. This eliminates the need for the user to invoke `--slurm_tmpdir` to write to `$SLURM_TMPDIR`. Documentation has also been updated to reflect this change.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
