### PR TITLE
Replace fslmaths with python scripts

### DIFF
--- a/scattr/workflow/rules/zona_bb_subcortex.smk
+++ b/scattr/workflow/rules/zona_bb_subcortex.smk
@@ -263,9 +263,9 @@ rule binarize:
     group:
         "subcortical_2"
     container:
-        config["singularity"]["neuroglia-core"]
-    shell:
-        "fslmaths {input.seg} -bin {output.mask} &> {log}"
+        config["singularity"]["scattr"]
+    script:
+        "../scripts/zona_bb_subcortex/create_seg_mask.py"
 
 
 rule add_brainstem:
@@ -289,9 +289,9 @@ rule add_brainstem:
     group:
         "subcortical_2"
     container:
-        config["singularity"]["neuroglia-core"]
-    shell:
-        "fslmaths {input.aparcaseg} -thr 16 -uthr 16 -bin -max {input.mask} {output.mask} &> {log}"
+        config["singularity"]["scattr"]
+    script:
+        "../scripts/zona_bb_subcortex/add_brainstem.py"
 
 
 rule create_convex_hull:

--- a/scattr/workflow/scripts/zona_bb_subcortex/add_brainstem.py
+++ b/scattr/workflow/scripts/zona_bb_subcortex/add_brainstem.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import nibabel as nib
+
+
+def add_brainstem(dseg_mask, aparcaseg, out_mask):
+    dseg_mask_data = nib.load(dseg_mask)
+    aparcaseg_data = nib.load(aparcaseg)
+    affine, header = aparcaseg_data.affine, aparcaseg_data.header
+
+    out_data = (aparcaseg_data.get_fdata() == 16) | (
+        dseg_mask_data.get_fdata() > 0
+    )
+    out_nii = nib.Nifti1Image(dataobj=out_data, affine=affine, header=header)
+    nib.save(out_nii, out_mask)
+
+
+if __name__ == "__main__":
+    add_brainstem(
+        dseg_mask=snakemake.input.mask,  # noqa: F821
+        aparcaseg=snakemake.input.aparcaseg,  # noqa: F821
+        out_mask=snakemake.output.mask,  # noqa: F821
+    )

--- a/scattr/workflow/scripts/zona_bb_subcortex/create_seg_mask.py
+++ b/scattr/workflow/scripts/zona_bb_subcortex/create_seg_mask.py
@@ -1,0 +1,18 @@
+#!/usr/env/bin python
+import nibabel as nib
+
+
+def create_seg_mask(dseg, out_mask):
+    dseg_data = nib.load(dseg)
+    affine, header = dseg_data.affine, dseg_data.header
+
+    out_data = dseg_data.get_fdata() > 0
+    out_nii = nib.Nifti1Image(dataobj=out_data, affine=affine, header=header)
+    nib.save(out_nii, out_mask)
+
+
+if __name__ == "__main__":
+    create_seg_mask(
+        dseg=snakemake.inputs.seg,  # noqa: F821
+        out_mask=snakemake.output.mask,  # noqa: F821
+    )


### PR DESCRIPTION
## Proposed changes

Resolves #64. Uses `nibabel` instead of `fslmaths` to perform necessary mathematical operations to create masks.
I thought about combining the two rules that called fslmaths, but ultimately decided against it (for now) to keep it simple for handling the `--skip_brainstem` option.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (if none of the other choices apply)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
