### PR TITLE
use single pybids_inputs instead of two

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     # Workflow files stored in the default location of `.github/workflows`. 
     # (You don't need to specify `/.github/workflows` for `directory`. 
     # You can use `directory: "/"`.)
-    directory: "/"
+    directory: /
     # Run on first of each month
     schedule:
-      interval: "monthly"
+      interval: monthly
     # Group to submit a single PR if possible
     groups:
       github-actions:
-        patterns:
-          - "*"
+        patterns: ['*']

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -12,7 +12,9 @@ supported**. We do not have a Docker arm64 container yet._
 
 ### Notes
 * Inputs to SCATTR should be a BIDS dataset, including processed Freesurfer
-and DWI derivatives (which can be stored separately). 
+and DWI derivatives. If any BIDS files are stored separately, you can point to these using the
+relevant `--path-{component}` CLI option. The Freesurfer folder is specified with a separate 
+CLI option `--freesurfer-dir`(which can be stored separately). 
 
 ## Docker on Windows / Mac (Intel) / Linux
 

--- a/docs/outputs/output_files.md
+++ b/docs/outputs/output_files.md
@@ -126,6 +126,3 @@ Workflow steps that write logs to file are stored in the hidden `.logs`
 subfolder, with the file names based on the tools used (e.g. `mrtrix`) and rule
 wildcards (e.g. `subject`).
 
-If the app is run in workflow mode (`--workflow-mode` / `-W`), which enables
-direct use of the Snakemake CLI to run scattr, output folders (e.g. `work`) will
-be placed in a `results` folder.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 docutils<0.18
-sphinx-argparse
+sphinx-argparse<0.5.0
 sphinx_rtd_theme
 sphinxcontrib-asciinema
 myst-parser

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -21,7 +21,7 @@ the dataset, so we suggest using the
 your dataset has no errors.
 
 If you passed Freesurfer or diffusion derivative locations (`--freesurfer-dir` 
-or `--dwi-dir`), you may get get this message as the files are a different
+or `--path-dwi`), you may get get this message as the files are a different
 location than in the input directory provided.
 
 ### 2. What if I want to use merge two different atlases?

--- a/docs/usage/useful_options.md
+++ b/docs/usage/useful_options.md
@@ -44,11 +44,19 @@ Similarly, subjects can be excluded from processing using the
 ## Alternate Freesurfer / derived-diffusion data locations
 
 By default, SCATTR attempts to locate Freesurfer and derived diffusion data 
-locations. Users can overwrite these options, by passing along the actual 
-location of each using either `--freesurfer_dir` or `--dwi_dir`, respectively.
+locations. Users can overwrite the Freesurfer location by passing `--freesurfer_dir`, 
+e.g.: 
 
 ```
---freesurfer_dir /path/to/fs_dir --dwi_dir /path/to/dwi_dir
+--freesurfer_dir /path/to/fs_dir
+```
+
+The paths to any of the BIDS files (T1w, dwi, dwi mask) can always be customized
+using the `--path-T1w`, `--path-dwi`, or `--path-mask` options. Note, you must
+include generic wildcards in any path you specify, e.g.:
+
+```
+--path-T1w /mydata/project1/sub-{subject}/T1.nii.gz`
 ```
 
 ## Pre-generated average response function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,14 +85,20 @@ python ./scattr/run.py ./test/data/bids test/data/derivatives/ participant \
 [tool.poe.tasks.test_dwi]
 shell = """
 python ./scattr/run.py ./test/data/bids_nodwi test/data/derivatives/ \
-    participant --dwi_dir ./test/data/derivatives/prepdwi \
+    participant --path-dwi \
+    ./test/data/derivatives/prepdwi/sub-{subject}/dwi/sub-{subject}_space-T1w_desc-preproc_dwi.nii.gz \
+    --path-mask \
+    ./test/data/derivatives/prepdwi/sub-{subject}/dwi/sub-{subject}_space-T1w_desc-preproc_mask.nii.gz \
     --fs-license ./test/.fs_license -np --force-output
 """
 
 [tool.poe.tasks.test_snakedwi]
 shell = """
 python ./scattr/run.py ./test/data/bids_nodwi test/data/derivatives/ \
-    participant --dwi_dir ./test/data/derivatives/snakedwi \
+    participant --path-dwi \
+    ./test/data/derivatives/snakedwi/sub-{subject}/dwi/sub-{subject}_space-T1w_desc-eddy_res-orig_dwi.nii.gz \
+    --path-dwi-mask \
+    ./test/data/derivatives/snakedwi/sub-{subject}/dwi/sub-{subject}_space-T1w_desc-eddy_res-orig_mask.nii.gz \
     --fs-license ./test/.fs_license -np --force-output
 """
 

--- a/scattr/config/snakebids.yml
+++ b/scattr/config/snakebids.yml
@@ -101,13 +101,6 @@ parse_args:
     nargs: "?"
     type: Path
 
-  --dwi_dir:
-    help: "The path to the directory containing pre-processed dwi data
-      transformed to subject T1w space. If not provided, workflow assumes
-      this data exists in <bids_dir>/<subject>/dwi."
-    nargs: "?"
-    type: Path
-
   --responsemean_dir:
     help: "The path to the directory containing average response functions. If
       not provided, one will be computed from the subjects in the input

--- a/scattr/config/snakebids.yml
+++ b/scattr/config/snakebids.yml
@@ -41,7 +41,7 @@ pybids_inputs:
       - subject
       - session
       - run
-  dwi_mask:
+  mask:
     filters:
       suffix: "mask"
       extension: ".nii.gz"

--- a/scattr/config/snakebids.yml
+++ b/scattr/config/snakebids.yml
@@ -31,7 +31,6 @@ pybids_inputs:
       - subject
       - session
       - run
-pybids_inputs_dwi:
   dwi:
     filters:
       suffix: "dwi"
@@ -42,7 +41,7 @@ pybids_inputs_dwi:
       - subject
       - session
       - run
-  mask:
+  dwi_mask:
     filters:
       suffix: "mask"
       extension: ".nii.gz"
@@ -106,11 +105,6 @@ parse_args:
     help: "The path to the directory containing pre-processed dwi data
       transformed to subject T1w space. If not provided, workflow assumes
       this data exists in <bids_dir>/<subject>/dwi."
-    nargs: "?"
-    type: Path
-
-  --pybidsdb_dwi_dir:
-    help: "The path to the pybids database associated with provided dwi_dir"
     nargs: "?"
     type: Path
 

--- a/scattr/config/snakebids.yml
+++ b/scattr/config/snakebids.yml
@@ -26,7 +26,6 @@ pybids_inputs:
       extension: ".nii.gz"
       datatype: "anat"
       desc: "brain" # Require a skull-stripped brain
-      part: ["mag", false]
     wildcards:
       - subject
       - session

--- a/scattr/workflow/Snakefile
+++ b/scattr/workflow/Snakefile
@@ -12,23 +12,11 @@ configfile: "config/snakebids.yml"
 
 
 # writes inputs_config.yml and updates config dict
-inputs_t1w = generate_inputs(
+inputs = generate_inputs(
     bids_dir=config["bids_dir"],
     pybids_inputs=config["pybids_inputs"],
     pybids_config=["bids", "derivatives"],
     pybidsdb_dir=config.get("pybidsdb_dir"),
-    pybidsdb_reset=config.get("pybidsdb_reset"),
-    derivatives=config["derivatives"],
-    participant_label=config["participant_label"],
-    exclude_participant_label=config["exclude_participant_label"],
-)
-inputs_dwi = generate_inputs(
-    bids_dir=config["dwi_dir"] if config["dwi_dir"] else config["bids_dir"],
-    pybids_inputs=config["pybids_inputs_dwi"],
-    pybids_config=["bids", "derivatives"],
-    pybidsdb_dir=config.get("pybidsdb_dwi_dir")
-    if config["dwi_dir"]
-    else config.get("pybidsdb_dir"),
     pybidsdb_reset=config.get("pybidsdb_reset"),
     derivatives=config["derivatives"],
     participant_label=config["participant_label"],
@@ -56,7 +44,7 @@ if config.get("labelmerge_base_dir") or config.get("labelmerge_overlay_dir"):
     """
     )
 
-if len(inputs_dwi.sessions) > 1 and not config.get("responsemean_ses"):
+if len(inputs.sessions) > 1 and not config.get("responsemean_ses"):
     print(
         """
     WARNING: Multiple sessions detected - average response function will be 
@@ -75,10 +63,10 @@ include: "rules/qc.smk"
 
 rule all:
     input:
-        tck_files=inputs_t1w["T1w"].expand(
+        tck_files=inputs["T1w"].expand(
             rules.filtered_tck2connectome.output.sl_assignment
         ),
-        dti_files=inputs_t1w["T1w"].expand(rules.dwi2tensor.output.dti),
+        dti_files=inputs["T1w"].expand(rules.dwi2tensor.output.dti),
         qc_files=rules.gather_qc.input,
     params:
         mrtrix_dir=mrtrix_dir,

--- a/scattr/workflow/rules/freesurfer.smk
+++ b/scattr/workflow/rules/freesurfer.smk
@@ -76,9 +76,7 @@ rule thalamic_segmentation:
         subj_dir=str(Path(bids(**inputs.subj_wildcards)).parent),
     output:
         thal_seg=str(
-            Path(
-                bids(root=freesurfer_dir, **inputs.subj_wildcards)
-            ).parent
+            Path(bids(root=freesurfer_dir, **inputs.subj_wildcards)).parent
             / "mri"
             / "ThalamicNuclei.v12.T1.mgz"
         ),
@@ -115,9 +113,7 @@ rule mgz2nii:
         if not config.get("skip_thal_seg")
         else [],
         aparcaseg=str(
-            Path(
-                bids(root=freesurfer_dir, **inputs.subj_wildcards)
-            ).parent
+            Path(bids(root=freesurfer_dir, **inputs.subj_wildcards)).parent
             / "mri"
             / "aparc+aseg.mgz"
         ),

--- a/scattr/workflow/rules/freesurfer.smk
+++ b/scattr/workflow/rules/freesurfer.smk
@@ -92,7 +92,7 @@ rule thalamic_segmentation:
         config["singularity"]["scattr"]
     shell:
         """
-        FS_LICENSE={params.fs_license}
+        export FS_LICENSE={params.fs_license}
         export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} 
         export SUBJECTS_DIR={input.freesurfer_dir} 
 
@@ -143,7 +143,7 @@ rule mgz2nii:
         config["singularity"]["scattr"]
     shell:
         """
-        FS_LICENSE={params.fs_license} 
+        export FS_LICENSE={params.fs_license} 
         export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} 
         export SUBJECTS_DIR={params.freesurfer_dir} 
 

--- a/scattr/workflow/rules/freesurfer.smk
+++ b/scattr/workflow/rules/freesurfer.smk
@@ -19,13 +19,13 @@ bids_fs_out = partial(
     bids,
     root=freesurfer_dir,
     datatype="anat",
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_log = partial(
     bids,
     root=log_dir,
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 """Freesurfer references (with additional in rules as necessary)
@@ -73,11 +73,11 @@ rule thalamic_segmentation:
         freesurfer_dir=freesurfer_dir,
     params:
         fs_license=fs_license,
-        subj_dir=str(Path(bids(**inputs_t1w.subj_wildcards)).parent),
+        subj_dir=str(Path(bids(**inputs.subj_wildcards)).parent),
     output:
         thal_seg=str(
             Path(
-                bids(root=freesurfer_dir, **inputs_t1w.subj_wildcards)
+                bids(root=freesurfer_dir, **inputs.subj_wildcards)
             ).parent
             / "mri"
             / "ThalamicNuclei.v12.T1.mgz"
@@ -116,7 +116,7 @@ rule mgz2nii:
         else [],
         aparcaseg=str(
             Path(
-                bids(root=freesurfer_dir, **inputs_t1w.subj_wildcards)
+                bids(root=freesurfer_dir, **inputs.subj_wildcards)
             ).parent
             / "mri"
             / "aparc+aseg.mgz"
@@ -162,7 +162,7 @@ rule fs_xfm_to_native:
     input:
         thal=rules.mgz2nii.output.thal,
         aparcaseg=rules.mgz2nii.output.aparcaseg,
-        ref=lambda wildcards: inputs_t1w["T1w"].filter(**wildcards).expand()[0],
+        ref=lambda wildcards: inputs["T1w"].filter(**wildcards).expand()[0],
     output:
         thal=bids_fs_out(
             space="T1w",

--- a/scattr/workflow/rules/mrtpipelines.smk
+++ b/scattr/workflow/rules/mrtpipelines.smk
@@ -30,21 +30,21 @@ bids_dti_out = partial(
     root=mrtrix_dir,
     datatype="dti",
     model="dti",
-    **inputs_dwi.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_tractography_out = partial(
     bids,
     root=mrtrix_dir,
     datatype="tractography",
-    **inputs_dwi.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_anat_out = partial(
     bids,
     root=mrtrix_dir,
     datatype="anat",
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_labelmerge = partial(
@@ -52,13 +52,13 @@ bids_labelmerge = partial(
     root=str(Path(labelmerge_dir) / "combined")
     if not config.get("skip_labelmerge")
     else config.get("labelmerge_base_dir") or zona_dir,
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_log = partial(
     bids,
     root=log_dir,
-    **inputs_dwi.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 """Mrtrix3 reference (additional citations are included per rule as necessary):

--- a/scattr/workflow/rules/mrtpipelines/preproc.smk
+++ b/scattr/workflow/rules/mrtpipelines/preproc.smk
@@ -3,7 +3,7 @@ rule nii2mif:
         dwi=inputs["dwi"].path,
         bval=re.sub(".nii.gz", ".bval", inputs["dwi"].path),
         bvec=re.sub(".nii.gz", ".bvec", inputs["dwi"].path),
-        mask=inputs["dwi_mask"].path,
+        mask=inputs["mask"].path,
     output:
         dwi=bids(
             root=mrtrix_dir,

--- a/scattr/workflow/rules/mrtpipelines/preproc.smk
+++ b/scattr/workflow/rules/mrtpipelines/preproc.smk
@@ -1,29 +1,29 @@
 rule nii2mif:
     input:
-        dwi=inputs_dwi["dwi"].path,
-        bval=re.sub(".nii.gz", ".bval", inputs_dwi["dwi"].path),
-        bvec=re.sub(".nii.gz", ".bvec", inputs_dwi["dwi"].path),
-        mask=inputs_dwi["mask"].path,
+        dwi=inputs["dwi"].path,
+        bval=re.sub(".nii.gz", ".bval", inputs["dwi"].path),
+        bvec=re.sub(".nii.gz", ".bvec", inputs["dwi"].path),
+        mask=inputs["dwi_mask"].path,
     output:
         dwi=bids(
             root=mrtrix_dir,
             datatype="dwi",
             suffix="dwi.mif",
-            **inputs_dwi.subj_wildcards
+            **inputs.subj_wildcards
         ),
         mask=bids(
             root=mrtrix_dir,
             datatype="dwi",
             desc="brain",
             suffix="mask.mif",
-            **inputs_dwi.subj_wildcards
+            **inputs.subj_wildcards
         ),
     threads: 4
     resources:
         mem_mb=16000,
         time=10,
     log:
-        bids_log(suffix="nii2mif.log", **inputs_dwi.subj_wildcards),
+        bids_log(suffix="nii2mif.log", **inputs.subj_wildcards),
     group:
         "dwiproc"
     container:
@@ -56,15 +56,15 @@ rule dwi2response:
     output:
         wm_rf=bids_response_out(
             desc="wm",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         gm_rf=bids_response_out(
             desc="gm",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         csf_rf=bids_response_out(
             desc="csf",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
     threads: 4
     resources:
@@ -89,13 +89,13 @@ rule dwi2response:
 
 def get_subject_rf(wildcards):
     """Get appropriate subject response path"""
-    if not inputs_dwi.sessions:
+    if not inputs.sessions:
         return expand(
             bids_response_out(
                 subject="{subject}",
                 desc="{tissue}",
             ),
-            subject=inputs_dwi.subjects,
+            subject=inputs.subjects,
             allow_missing=True,
         )
     else:
@@ -105,11 +105,11 @@ def get_subject_rf(wildcards):
                 session="{session}",
                 desc="{tissue}",
             ),
-            subject=inputs_dwi.subjects,
+            subject=inputs.subjects,
             session=(
                 config.get("responsemean_ses")
                 if config.get("responsemean_ses")
-                else inputs_dwi.sessions
+                else inputs.sessions
             ),
             allow_missing=True,
         )
@@ -184,19 +184,19 @@ rule dwi2fod:
             model="csd",
             desc="wm",
             suffix="fod.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         gm_fod=bids_response_out(
             model="csd",
             desc="gm",
             suffix="fod.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         csf_fod=bids_response_out(
             model="csd",
             desc="csf",
             suffix="fod.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
     threads: 4
     resources:
@@ -239,19 +239,19 @@ rule mtnormalise:
             model="csd",
             desc="wm",
             suffix="fodNormalized.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         gm_fod=bids_response_out(
             model="csd",
             desc="gm",
             suffix="fodNormalized.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
         csf_fod=bids_response_out(
             model="csd",
             desc="csf",
             suffix="fodNormalized.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
     threads: 4
     resources:
@@ -286,7 +286,7 @@ rule dwinormalise:
             datatype="dwi",
             desc="normalized",
             suffix="dwi.mif",
-            **inputs_dwi.subj_wildcards,
+            **inputs.subj_wildcards,
         ),
     threads: 4
     resources:

--- a/scattr/workflow/rules/mrtpipelines/tractography.smk
+++ b/scattr/workflow/rules/mrtpipelines/tractography.smk
@@ -89,7 +89,7 @@ checkpoint create_roi_mask:
         num_labels=rules.get_num_nodes.output.num_labels,
     params:
         base_dir=mrtrix_dir,
-        subj_wildcards=inputs_dwi.subj_wildcards,
+        subj_wildcards=inputs.subj_wildcards,
     output:
         out_dir=directory(bids_anat_out(datatype="roi_masks")),
     threads: 4
@@ -151,7 +151,7 @@ checkpoint create_exclude_mask:
         mask_dir=bids_anat_out(
             datatype="roi_masks",
         ),
-        subj_wildcards=inputs_dwi.subj_wildcards,
+        subj_wildcards=inputs.subj_wildcards,
     output:
         out_dir=directory(bids_anat_out(datatype="exclude_mask")),
     threads: 4

--- a/scattr/workflow/rules/qc.smk
+++ b/scattr/workflow/rules/qc.smk
@@ -4,7 +4,7 @@ bids_labelmerge = partial(
     root=str(Path(labelmerge_dir) / "combined")
     if not config.get("skip_labelmerge")
     else config.get("labelmerge_base_dir") or zona_dir,
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_qc = partial(
@@ -12,7 +12,7 @@ bids_qc = partial(
     root=str(Path(config["output_dir"]) / "qc"),
     datatype="anat",
     space="T1w",
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 
@@ -26,7 +26,7 @@ rule segment_qc:
             else config.get("labelmerge_base_desc"),
             suffix="dseg.nii.gz",
         ),
-        t1w_image=lambda wildcards: inputs_t1w["T1w"]
+        t1w_image=lambda wildcards: inputs["T1w"]
         .filter(**wildcards)
         .expand()[0],
     output:
@@ -66,7 +66,7 @@ rule segment_qc:
 rule registration_qc:
     input:
         moving_nii=rules.reg2native.output.t1w_nativespace,
-        fixed_nii=lambda wildcards: inputs_t1w["T1w"]
+        fixed_nii=lambda wildcards: inputs["T1w"]
         .filter(**wildcards)
         .expand()[0],
     params:
@@ -103,7 +103,7 @@ rule registration_qc:
 
 rule gather_qc:
     input:
-        dseg_png=inputs_t1w["T1w"].expand(rules.segment_qc.output.qc_png),
-        dseg_html=inputs_t1w["T1w"].expand(rules.segment_qc.output.qc_html),
-        reg_svg=inputs_t1w["T1w"].expand(rules.registration_qc.output.qc_svg),
-        reg_html=inputs_t1w["T1w"].expand(rules.registration_qc.output.qc_html),
+        dseg_png=inputs["T1w"].expand(rules.segment_qc.output.qc_png),
+        dseg_html=inputs["T1w"].expand(rules.segment_qc.output.qc_html),
+        reg_svg=inputs["T1w"].expand(rules.registration_qc.output.qc_svg),
+        reg_html=inputs["T1w"].expand(rules.registration_qc.output.qc_html),

--- a/scattr/workflow/rules/zona_bb_subcortex.smk
+++ b/scattr/workflow/rules/zona_bb_subcortex.smk
@@ -12,7 +12,7 @@ bids_anat = partial(
     bids,
     root=zona_dir,
     datatype="anat",
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_labelmerge = partial(
@@ -20,13 +20,13 @@ bids_labelmerge = partial(
     root=str(Path(labelmerge_dir) / "combined")
     if not config.get("skip_labelmerge")
     else config.get("labelmerge_base_dir") or zona_dir,
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 bids_log = partial(
     bids,
     root=log_dir,
-    **inputs_t1w.subj_wildcards,
+    **inputs.subj_wildcards,
 )
 
 """ References:
@@ -71,7 +71,7 @@ rule reg2native:
             / Path(config["zona_bb_subcortex"][config["Space"]]["dir"])
             / Path(config["zona_bb_subcortex"][config["Space"]]["T1w"])
         ),
-        target=lambda wildcards: inputs_t1w["T1w"]
+        target=lambda wildcards: inputs["T1w"]
         .filter(**wildcards)
         .expand()[0],
     params:
@@ -155,12 +155,12 @@ rule warp2native:
 
 rule labelmerge:
     input:
-        zona_seg=inputs_t1w["T1w"].expand(
+        zona_seg=inputs["T1w"].expand(
             rules.warp2native.output.nii, allow_missing=True
         )
         if not config.get("labelmerge_base_dir")
         else [],
-        fs_seg=inputs_t1w["T1w"].expand(
+        fs_seg=inputs["T1w"].expand(
             rules.fs_xfm_to_native.output.thal, allow_missing=True
         )
         if not config.get("labelmerge_overlay_dir")
@@ -200,7 +200,7 @@ rule labelmerge:
             else ""
         ),
     output:
-        seg=inputs_t1w["T1w"].expand(
+        seg=inputs["T1w"].expand(
             bids_labelmerge(
                 space="T1w",
                 desc="combined",
@@ -208,7 +208,7 @@ rule labelmerge:
             ),
             allow_missing=True,
         ),
-        tsv=inputs_t1w["T1w"].expand(
+        tsv=inputs["T1w"].expand(
             bids_labelmerge(
                 space="T1w",
                 desc="combined",

--- a/scattr/workflow/rules/zona_bb_subcortex.smk
+++ b/scattr/workflow/rules/zona_bb_subcortex.smk
@@ -71,9 +71,7 @@ rule reg2native:
             / Path(config["zona_bb_subcortex"][config["Space"]]["dir"])
             / Path(config["zona_bb_subcortex"][config["Space"]]["T1w"])
         ),
-        target=lambda wildcards: inputs["T1w"]
-        .filter(**wildcards)
-        .expand()[0],
+        target=lambda wildcards: inputs["T1w"].filter(**wildcards).expand()[0],
     params:
         out_dir=directory(str(Path(bids_anat()).parent)),
         out_prefix=bids_anat(


### PR DESCRIPTION
Removes pybids_inputs_dwi.

Having two was problematic since the pybids_inputs_dwi wasn't changeable from the CLI options.

## Proposed changes

Find/replace: 
  pybids_inputs_dwi -> pybids_inputs
  inputs_t1 -> inpts
  inputs_dwi -> inputs
  mask -> dwi_mask

So far only dry-run testing done, but that should be sufficient given the change.

## Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] Code has been run through the `poe quality` task
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.
